### PR TITLE
perf(chronos): replace DatePipe with `formateDate`

### DIFF
--- a/packages/chronos/src/lib/timeline.ts
+++ b/packages/chronos/src/lib/timeline.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at the root of this project.
  */
 
-import { CommonModule, DatePipe } from '@angular/common';
+import { CommonModule, formatDate } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -71,7 +71,6 @@ export class NgxChronosTimeline implements OnInit, OnDestroy {
   private readonly elementRef = inject(ElementRef) as ElementRef<HTMLElement>;
   private readonly idle = inject(IdleObserver);
   private readonly config = inject(ChronTimelineConfig);
-  private readonly datePipe = new DatePipe('en');
 
   private readonly lineSegment = signal(0);
 
@@ -195,7 +194,10 @@ export class NgxChronosTimeline implements OnInit, OnDestroy {
         return label?.timestamp;
       });
 
-      this.ariaLabel = computed(() => this.datePipe.transform(this.labelDisplayText(), 'MMMM y'));
+      this.ariaLabel = computed(() => {
+        const label = this.labelDisplayText();
+        return label ? formatDate(label, 'MMMM y', 'en') : null;
+      });
     });
 
     // Observe idle changes


### PR DESCRIPTION
We incorrectly created an instance of `DatePipe` to transform the active timeline segment's timestamp. This was because Angular doesn't allow using pipes in host bindings; so this was a way to circumvent that limitation.

Since we import `CommonModule`, which already provides the `date` pipe, we basically have duplicate instances.

Now we make use of the `formatDate` function provided `@angular/common` package to format the segment's timestamp.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
